### PR TITLE
Fix travis matrix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ ENV/
 .ropeproject
 .idea
 .DS_Store
+
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: scala
 
+# keep versions in sync with build.sbt
 scala:
-  - 2.9.3
-  - 2.10.4
-  - 2.11.8
+  - 2.12.7
+  - 2.11.12
+  - 2.10.7
 
 script:
-  - BongoSort.scala
-  - BubbleSort.scala
-  - InsertionSort.scala
-  - QuickSort.scala
-  - RecursiveInsertion.scala
-  - SelectionSort.scala
+  - sbt ++${TRAVIS_SCALA_VERSION} test

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "TheAlgorithmsScala"
 
 version := "0.1"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.7"
+crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.10.7") // keep versions in sync with .travis.yml
 
-libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.4"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.3
+sbt.version = 1.2.4


### PR DESCRIPTION
Cleanup build.sbt and fix travis.yml to support automatic build on the last 3 scala versions:
* 2.10.x
* 2.11.x
* 2.12.x

Do we want to build on all 3 versions ?

Could a committer after merging this enable travis build for this repo here:
https://travis-ci.org/TheAlgorithms/Scala

Thanks